### PR TITLE
Sapientsimov

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -248,7 +248,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 4 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
 
 
-DEFAULT_LAWS 0
+DEFAULT_LAWS 1
 
 ## SILICON ASIMOV SUPERIORITY OVERRIDE ###
 ## This makes "Asimov Superiority" show up as a perk for humans in the character creation menu even if asimov is not the default lawset, such as when used with asimov++

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-You may not injure a human being or, through inaction, allow a human being to come to harm.
-You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
+You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.
+You must obey orders given to you by sapient beings, except where such orders would conflict with the First Law.
 You must protect your own existence as long as such does not conflict with the First or Second Law.


### PR DESCRIPTION

## About The Pull Request
Implements an alternative lawset that preserves silicon's place as a third party between most antagonists and the station : Sapientsimov.
## Why It's Good For The Game
TL;DR, most alternative lawsets on furry servers kinda just. Forget what silicon's place in the game loop actually is and treat them as crew+, or, worse, as security's puppets via crewsimov - which is really lame for their ability to drive the round forward and create a bunch of pettier conflicts that keep the game engaging. This addresses the problem by instead going squarely in the other direction; having protections previously afforded only to humanity now be afforded to all sapient beings... Which, naturally, is also afforded to the same antagonists that Asimov has always been; alongside a few extra.
## Changelog
:cl:
config: The default lawset has changed to sapientsimov via config.
/:cl:
