### PR TITLE
Effigy Map Parity - Tech Storage

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -16740,9 +16740,10 @@
 /area/station/command/heads_quarters/qm)
 "fSo" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
-/obj/item/kirbyplants/random,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "fSQ" = (

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -80505,7 +80505,6 @@
 /area/station/medical/medbay/central)
 "sEh" = (
 /obj/structure/rack,
-/obj/item/electronics/apc,
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -80513,9 +80512,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/mid_joiner{
 	dir = 8
 	},
-/obj/item/electronics/apc,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/large,
 /area/station/engineering/storage/tech)
 "sEq" = (


### PR DESCRIPTION
Didn't catch this originally; tech storage was updated to have custom shuttle equipment - this' been mirrored over.