### PR TITLE
Fix ears defaulting to cat

### DIFF
--- a/local/code/modules/character_prefs/preferences/species_features/ears.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/ears.dm
@@ -73,7 +73,6 @@
 	main_feature_name = "Ears"
 
 /datum/preference/choiced/felinid_ears/apply_to_human(mob/living/carbon/human/target, value)
-	..()
 	if(target.dna.ear_type == CAT_TYPE)
 		target.dna.features["ears"] = value
 


### PR DESCRIPTION

## About The Pull Request

`/datum/preference/choiced/felinid_ears/apply_to_human` shouldn't be calling its parent because that unconditionally sets `dna.features["ears"]` to the cat value instead of checking if the variation chosen is actually the cat ones

## Why It's Good For The Game

Fixes #64 

## Changelog

Naw