### PR TITLE
Fixes Cryo Latejoining Runtiming If Some GOOBER Destroys Them All

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -504,7 +504,9 @@
 		var/their_latejoin_pref = potential_alt_spawner?.client.prefs.read_preference(/datum/preference/choiced/latejoin_location)
 		if(their_latejoin_pref)
 			if(their_latejoin_pref == JOB_LATEJOINPREF_CRYO)
-				return pick(SSjob.latejoin_cryo_trackers)
+				var/possible_spawn = pick(SSjob.latejoin_cryo_trackers)
+				if(possible_spawn) // Sanitycheck - if there aren't any cryopods anymore; pass them onto arrivals as normal.
+					return pick(SSjob.latejoin_cryo_trackers)
 	// EffigyEdit Change End
 	if(length(SSjob.latejoin_trackers))
 		return pick(SSjob.latejoin_trackers)


### PR DESCRIPTION
never change

:cl:
fix: Attempting to latejoin via cryo while no cryopods exist will no longer destroy you with hammers.
/:cl:
