### PR TITLE
Recolors Cryo Decals

### DIFF
--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -4715,8 +4715,8 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/white/warning,
 /obj/effect/turf_decal/trimline/white/mid_joiner,
 /obj/machinery/airalarm/directional/south,
@@ -13076,13 +13076,13 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/warning{
+/obj/effect/turf_decal/trimline/dark_purple/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark_blue{
+/obj/effect/turf_decal/siding/dark_purple{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14221,8 +14221,8 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/white/warning,
 /obj/effect/turf_decal/trimline/white/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
@@ -24804,10 +24804,10 @@
 /area/station/security/brig/upper)
 "nKf" = (
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/warning{
@@ -26288,13 +26288,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ozS" = (
-/obj/effect/turf_decal/trimline/blue/warning{
+/obj/effect/turf_decal/trimline/dark_purple/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/mid_joiner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -41575,10 +41575,10 @@
 /area/station/security/prison)
 "wpI" = (
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/warning{
@@ -44111,8 +44111,8 @@
 /obj/structure/chair/sofa/bench/tram/solo{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/white/warning,
 /obj/effect/turf_decal/trimline/white/mid_joiner,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -44253,13 +44253,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/mess)
 "xJP" = (
-/obj/effect/turf_decal/trimline/blue/warning{
+/obj/effect/turf_decal/trimline/dark_purple/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/mid_joiner{
 	dir = 8
 	},
 /obj/machinery/computer/cryopod/directional/west,

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -5235,7 +5235,7 @@
 /obj/machinery/cryopod,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -10524,6 +10524,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Service - Locker Room, Southeast"
 	},
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dHn" = (
@@ -18984,7 +18985,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
 /turf/open/floor/iron/white,
 /area/station/commons/cryo)
 "gEu" = (
@@ -26964,7 +26965,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -55277,7 +55278,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/commons/cryo)
@@ -62059,7 +62060,7 @@
 "vCc" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
@@ -63028,7 +63029,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_purple/filled/line,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/commons/cryo)

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -30849,7 +30849,7 @@
 /turf/open/floor/iron/dark/side,
 /area/station/medical/morgue)
 "kNJ" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
@@ -43111,7 +43111,7 @@
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
@@ -45564,7 +45564,7 @@
 /turf/closed/wall/mineral/wood/nonmetal,
 /area/station/commons/dorms/room2)
 "qbp" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{

--- a/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
+++ b/_maps/effigy/map_files/SigmaOctantis/SigmaOctantis.dmm
@@ -1099,7 +1099,7 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
@@ -14647,7 +14647,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
@@ -24353,7 +24353,7 @@
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "fBT" = (
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 9
@@ -27549,13 +27549,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gnl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_cw{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -31277,13 +31277,13 @@
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
 "hfm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_cw{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -48963,13 +48963,13 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/security/warden)
 "lnd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_cw{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -62623,13 +62623,13 @@
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/floor2/fore)
 "oxT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_cw{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -64229,13 +64229,13 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "oRh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_ccw{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -82246,7 +82246,7 @@
 /obj/machinery/cryopod/no_latejoin{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 10
 	},
@@ -83242,7 +83242,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
 "tlZ" = (
@@ -96351,7 +96351,7 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
@@ -97523,13 +97523,13 @@
 /turf/open/misc/dirt/station,
 /area/station/security/prison/garden)
 "wCo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+/obj/effect/turf_decal/trimline/dark_purple/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+/obj/effect/turf_decal/trimline/dark_purple/arrow_ccw{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -101911,7 +101911,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
@@ -104968,7 +104968,7 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/tile/dark_purple/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/commons/cryo)
 "ylO" = (


### PR DESCRIPTION

## About The Pull Request
Updates the color schema of cryogenics to white/purple; as john space intended.
## Why It's Good For The Game
Consistent with the pods themselves, now!
## Changelog
:cl:
map: WHAT IF IT - AND BY IT I MEAN CRYOPODS - WERE PURPLE!?
/:cl:
