### PR TITLE
Fix lobby name display

### DIFF
--- a/code/__DEFINES/~effigy/signals.dm
+++ b/code/__DEFINES/~effigy/signals.dm
@@ -27,7 +27,7 @@
 //from base of living/CanAllowThrough(): (atom/movable/mover, border_dir)
 #define COMSIG_LIVING_CAN_ALLOW_THROUGH "living_can_allow_through"
 
-//when a new character slot is selected
-#define COMSIG_CHARACTER_SLOT_CHANGED "character_slot_changed"
+//when a character name is changed
+#define COMSIG_PREFERENCES_NAME_APPLIED "preferences_name_applied"
 //increment init screen loading bar
 #define COMSIG_SUBSYSTEM_INCREMENT_PROGRESS "increment_progress"

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -249,7 +249,7 @@
 		if(!isnull(character_prefs))
 			var/character_name = character_prefs.read_preference(/datum/preference/name/real_name)
 			update_character_name(new_name = character_name)
-			RegisterSignal(character_prefs, COMSIG_CHARACTER_SLOT_CHANGED, PROC_REF(update_character_name))
+			RegisterSignal(character_prefs, COMSIG_PREFERENCES_NAME_APPLIED, PROC_REF(update_character_name))
 	// EffigyEdit Add End
 
 	// We need IconForge and the assets to be ready before allowing the menu to open

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -565,6 +565,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		character.update_body(is_creating = TRUE)
 
 	SEND_SIGNAL(character, COMSIG_HUMAN_PREFS_APPLIED)
+	SEND_SIGNAL(src, COMSIG_PREFERENCES_NAME_APPLIED, character.real_name) // EffigyEdit Add - Custom Lobby
 
 /// Returns whether the parent mob should have the random hardcore settings enabled. Assumes it has a mind.
 /datum/preferences/proc/should_be_random_hardcore(datum/job/job, datum/mind/mind)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -412,11 +412,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	character_preview_view.update_body()
 
-	// EffigyEdit Add - Custom Lobby
-	var/new_character = read_preference(/datum/preference/name/real_name)
-	SEND_SIGNAL(src, COMSIG_CHARACTER_SLOT_CHANGED, new_character)
-	// EffigyEdit Add End
-
 /datum/preferences/proc/remove_current_slot()
 	PRIVATE_PROC(TRUE)
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/EffigyPreferences/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/EffigyPreferences/names.tsx
@@ -153,8 +153,7 @@ export function NameInput(props: NameInputProps) {
           {editing ? (
             <Input
               autoSelect
-              expensive
-              onChange={updateName}
+              onBlur={updateName}
               onEscape={() => {
                 setLastNameBeforeEdit(null);
               }}


### PR DESCRIPTION
## About The Pull Request

Fixes updating the lobby screen name display when character name is changed using the dialog box.

:cl: LT3
fix: Lobby name display updates correctly when renaming without changing slots
/:cl: