### PR TITLE
Fix opendream lint ignoring pragma settings

### DIFF
--- a/effigy.dme
+++ b/effigy.dme
@@ -18,6 +18,7 @@
 // END_PREFERENCES
 
 // BEGIN_INCLUDE
+#include "__odlint.dm"
 #include "_maps\_basemap.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"


### PR DESCRIPTION

## About The Pull Request

I was wondering why our opendream lint was still raising warnings about the BYOND premium related code when there was a pragma added months ago to disable them and it turns out because we just don't include the settings file in our dme so let's do that (hopefully doesn't mean a ton of linter errors)

## Why It's Good For The Game

We love a configurable linter
