### PR TITLE
Increase file limit of codeowner review workflow

### DIFF
--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -19,6 +19,8 @@ jobs:
         if: github.event.pull_request.draft == false
         id: CodeOwnersParser
         uses: tgstation/CodeOwnersParser@v1
+        with:
+          fileLimit: 2000
 
       #Request reviews
       - name: Request reviews
@@ -26,5 +28,4 @@ jobs:
         uses: tgstation/RequestReviewFromUser@v1
         with:
           separator: " "
-          fileLimit: 2000
           users: ${{ steps.CodeOwnersParser.outputs.owners }}

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -26,4 +26,5 @@ jobs:
         uses: tgstation/RequestReviewFromUser@v1
         with:
           separator: " "
+          fileLimit: 2000
           users: ${{ steps.CodeOwnersParser.outputs.owners }}


### PR DESCRIPTION
Sometimes the upstreams are over 1k and it makes the workflow fail which makes me sad