### PR TITLE
Some mutant part fixes

### DIFF
--- a/code/__DEFINES/~effigy/mutants.dm
+++ b/code/__DEFINES/~effigy/mutants.dm
@@ -24,29 +24,19 @@ GLOBAL_LIST_INIT(mutant_variations, list(
 	MAMMAL_TYPE,
 ))
 
-#define ANTENNAE "antennae"
-#define CYBER_FRAME "cyber_frame"
-#define CYBER_ORGANS "cyber_organs"
-#define EARS "ears"
-#define FLUFF "fluff"
-#define FRILLS "frills"
-#define HORNS "horns"
-#define DIGI_LEGS "digi_legs"
-#define SNOUT "snout"
-#define LIZARD_MARKING "lizard_marking"
-#define MOTH_MARKING "moth_marking"
-#define MUSHROOM_CAP "mush_cap"
-#define SPINES "spines"
-#define TAIL "tail"
-#define WINGS "wings"
+#define FEATURE_CYBER_FRAME "cyber_frame"
+#define FEATURE_CYBER_ORGANS "cyber_organs"
+#define FEATURE_FLUFF "fluff"
+#define FEATURE_DIGI_LEGS "digi_legs"
+#define FEATURE_TAIL "tail"
 
 GLOBAL_LIST_INIT(bodypart_allowed_species, list(
-	ANTENNAE = list(
+	FEATURE_MOTH_ANTENNAE = list(
 		/datum/species/android,
 		/datum/species/insectoid,
 		/datum/species/moth,
 	),
-	CYBER_FRAME = list(
+	FEATURE_CYBER_FRAME = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/human,
@@ -56,7 +46,7 @@ GLOBAL_LIST_INIT(bodypart_allowed_species, list(
 		/datum/species/plasmaman,
 		/datum/species/synth,
 	),
-	CYBER_ORGANS = list(
+	FEATURE_CYBER_ORGANS = list(
 		/datum/species/animalid,
 		/datum/species/human,
 		/datum/species/insectoid,
@@ -64,28 +54,28 @@ GLOBAL_LIST_INIT(bodypart_allowed_species, list(
 		/datum/species/moth,
 		/datum/species/plasmaman,
 	),
-	EARS = list(
+	FEATURE_EARS = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/insectoid,
 		/datum/species/synth,
 	),
-	FLUFF = list(
+	FEATURE_FLUFF = list(
 		/datum/species/moth,
 	),
-	FRILLS = list(
+	FEATURE_FRILLS = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/lizard,
 		/datum/species/synth,
 	),
-	HORNS = list(
+	FEATURE_HORNS = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/lizard,
 		/datum/species/synth,
 	),
-	DIGI_LEGS = list(
+	FEATURE_DIGI_LEGS = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/insectoid,
@@ -93,21 +83,21 @@ GLOBAL_LIST_INIT(bodypart_allowed_species, list(
 		/datum/species/moth,
 		/datum/species/synth,
 	),
-	SNOUT = list(
+	FEATURE_SNOUT = list(
 		/datum/species/animalid,
 		/datum/species/android,
 		/datum/species/insectoid,
 		/datum/species/lizard,
 		/datum/species/synth,
 	),
-	TAIL = list(
+	FEATURE_TAIL = list(
 		/datum/species/animalid,
 		/datum/species/android,
 		/datum/species/insectoid,
 		/datum/species/lizard,
 		/datum/species/synth,
 	),
-	WINGS = list(
+	FEATURE_WINGS = list(
 		/datum/species/android,
 		/datum/species/animalid,
 		/datum/species/insectoid,

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -2,7 +2,7 @@
 /// The default priority level
 #define PREFERENCE_PRIORITY_DEFAULT 1
 
-#define PREFERENCE_PRIORITY_PRE_SPECIES 2 // EffigyEdit Add - Priority after highest but before species is set, used for tail variation pref
+#define PREFERENCE_PRIORITY_PRE_SPECIES 2 // EffigyEdit Add - Priority after highest but before species is set, used for tail/ears variation prefs
 
 /// The priority at which species runs, needed for external organs to apply properly.
 #define PREFERENCE_PRIORITY_SPECIES 3 // EffigyEdit Change - Original: 2

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -2,35 +2,37 @@
 /// The default priority level
 #define PREFERENCE_PRIORITY_DEFAULT 1
 
+#define PREFERENCE_PRIORITY_PRE_SPECIES 2 // EffigyEdit Add - Priority after highest but before species is set, used for tail variation pref
+
 /// The priority at which species runs, needed for external organs to apply properly.
-#define PREFERENCE_PRIORITY_SPECIES 2
+#define PREFERENCE_PRIORITY_SPECIES 3 // EffigyEdit Change - Original: 2
 
 /**
  * Some preferences get applied directly to bodyparts (anything head_flags related right now).
  * These must apply after species, as species gaining might replace the bodyparts of the human.
  */
-#define PREFERENCE_PRIORITY_BODYPARTS 3
+#define PREFERENCE_PRIORITY_BODYPARTS 4 // EffigyEdit Change - Original: 3
 
 /// The priority at which gender is determined, needed for proper randomization.
-#define PREFERENCE_PRIORITY_GENDER 4
+#define PREFERENCE_PRIORITY_GENDER 5 // EffigyEdit Change - Original: 4
 
 /// The priority at which body type is decided, applied after gender so we can
 /// support the "use gender" option.
-#define PREFERENCE_PRIORITY_BODY_TYPE 5
+#define PREFERENCE_PRIORITY_BODY_TYPE 6 // EffigyEdit Change - Original: 5
 
 /// Used for preferences that rely on body setup being finalized.
-#define PREFERENCE_PRORITY_LATE_BODY_TYPE 6
+#define PREFERENCE_PRORITY_LATE_BODY_TYPE 7 // EffigyEdit Change - Original: 6
 
 /// Equpping items based on preferences.
 /// Should happen after species and body type to make sure it looks right.
 /// Mostly redundant, but a safety net for saving/loading.
-#define PREFERENCE_PRIORITY_LOADOUT 7
+#define PREFERENCE_PRIORITY_LOADOUT 8 // EffigyEdit Change - Original: 7
 
 /// The priority at which names are decided, needed for proper randomization.
-#define PREFERENCE_PRIORITY_NAMES 8
+#define PREFERENCE_PRIORITY_NAMES 9 // EffigyEdit Change - Original: 8
 
 /// Preferences that aren't names, but change the name changes set by PREFERENCE_PRIORITY_NAMES.
-#define PREFERENCE_PRIORITY_NAME_MODIFICATIONS 9
+#define PREFERENCE_PRIORITY_NAME_MODIFICATIONS 10 // EffigyEdit Change - Original: 9
 
 /// The maximum preference priority, keep this updated, but don't use it for `priority`.
 #define MAX_PREFERENCE_PRIORITY PREFERENCE_PRIORITY_NAME_MODIFICATIONS

--- a/local/code/modules/character_prefs/preferences/species_features/antennae.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/antennae.dm
@@ -7,7 +7,7 @@
 
 /datum/preference/toggle/antennae/apply_to_human(mob/living/carbon/human/target, value)
 	if(value == FALSE)
-		target.dna.features["moth_antennae"] = /datum/sprite_accessory/moth_antennae/none::name
+		target.dna.features[FEATURE_MOTH_ANTENNAE] = /datum/sprite_accessory/moth_antennae/none::name
 
 /datum/preference/toggle/antennae/create_default_value()
 	return FALSE
@@ -15,7 +15,7 @@
 /datum/preference/toggle/antennae/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[ANTENNAE]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_MOTH_ANTENNAE]))
 		return FALSE
 
 	return TRUE
@@ -54,7 +54,7 @@
 /datum/preference/choiced/species_feature/moth_antennae/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[ANTENNAE]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_MOTH_ANTENNAE]))
 		return FALSE
 
 	var/has_antennae = preferences.read_preference(/datum/preference/toggle/antennae)
@@ -114,8 +114,8 @@
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features["moth_antennae"] && (type in GLOB.bodypart_allowed_species[ANTENNAE]))
-		if(target.dna.features["moth_antennae"] != /datum/sprite_accessory/moth_antennae/none::name && target.dna.features["moth_antennae"] != /datum/sprite_accessory/blank::name)
+	if(target.dna.features[FEATURE_MOTH_ANTENNAE] && (type in GLOB.bodypart_allowed_species[FEATURE_MOTH_ANTENNAE]))
+		if(target.dna.features[FEATURE_MOTH_ANTENNAE] != /datum/sprite_accessory/moth_antennae/none::name && target.dna.features[FEATURE_MOTH_ANTENNAE] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/antennae)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 			return .

--- a/local/code/modules/character_prefs/preferences/species_features/cyber_limbs.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/cyber_limbs.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(frame_type_names, list(
 /datum/preference/choiced/chest_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return FALSE
 
 	return TRUE
@@ -133,7 +133,7 @@ GLOBAL_LIST_INIT(frame_type_names, list(
 /datum/preference/choiced/arm_r_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return FALSE
 
 	return TRUE
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(frame_type_names, list(
 /datum/preference/choiced/arm_l_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return FALSE
 
 	return TRUE
@@ -195,7 +195,7 @@ GLOBAL_LIST_INIT(frame_type_names, list(
 /datum/preference/choiced/leg_r_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return FALSE
 
 	return TRUE
@@ -229,14 +229,14 @@ GLOBAL_LIST_INIT(frame_type_names, list(
 /datum/preference/choiced/leg_l_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return FALSE
 
 	return TRUE
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features["frame_list"] && (type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(target.dna.features["frame_list"] && (type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		//head
 		if(target.dna.features["frame_list"][BODY_ZONE_HEAD] && type == /datum/species/synth)
 			var/obj/item/bodypart/head/old_limb = target.get_bodypart(BODY_ZONE_HEAD)

--- a/local/code/modules/character_prefs/preferences/species_features/cyber_organs.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/cyber_organs.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/heart_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/lungs_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/liver_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -137,7 +137,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/stomach_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -170,7 +170,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/eyes_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -203,7 +203,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/tongue_type/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE
@@ -235,7 +235,7 @@ GLOBAL_LIST_INIT(organ_type_names, list(
 /datum/preference/choiced/breathing_tube/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[CYBER_ORGANS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_CYBER_ORGANS]))
 		return FALSE
 
 	return TRUE

--- a/local/code/modules/character_prefs/preferences/species_features/ears.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/ears.dm
@@ -62,6 +62,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = FEATURE_EARS
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/felinid_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == CAT_TYPE)
@@ -94,6 +95,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_lizard"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/lizard_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == LIZARD_TYPE)
@@ -126,6 +128,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_fox"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/fox_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == FOX_TYPE)
@@ -158,6 +161,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_dog"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/dog_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
@@ -190,6 +194,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_flying"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/flying_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == FLYING_TYPE)
@@ -222,6 +227,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_monkey"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/monkey_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == MONKEY_TYPE)
@@ -254,6 +260,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_mammal"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/mammal_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == MAMMAL_TYPE)
@@ -286,6 +293,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_fish"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/fish_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == AQUATIC_TYPE)
@@ -318,6 +326,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_humanoid"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/humanoid_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == HUMANOID_TYPE)
@@ -350,6 +359,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Ears"
 	feature_key = "ears_synthetic"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/synthetic_ears/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.ear_type == CYBERNETIC_TYPE)

--- a/local/code/modules/character_prefs/preferences/species_features/ears.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/ears.dm
@@ -16,10 +16,10 @@
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features["ears"] && (type in GLOB.bodypart_allowed_species[EARS]))
+	if(target.dna.features[FEATURE_EARS] && (type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		if(target.dna.ear_type == NO_VARIATION)
 			return .
-		else if(target.dna.features["ears"] != /datum/sprite_accessory/ears/none::name && target.dna.features["ears"] != /datum/sprite_accessory/blank::name)
+		else if(target.dna.features[FEATURE_EARS] != /datum/sprite_accessory/ears/none::name && target.dna.features[FEATURE_EARS] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/organ_path
 			if(target.dna.ear_type == AQUATIC_TYPE)
 				organ_path = text2path("/obj/item/organ/ears/fish")
@@ -39,7 +39,7 @@
 /datum/preference/choiced/ear_variation/apply_to_human(mob/living/carbon/human/target, chosen_variation)
 	target.dna.ear_type = chosen_variation
 	if(chosen_variation == NO_VARIATION)
-		target.dna.features["ears"] = /datum/sprite_accessory/ears/none::name
+		target.dna.features[FEATURE_EARS] = /datum/sprite_accessory/ears/none::name
 
 /datum/preference/choiced/ear_variation/create_default_value()
 	return NO_VARIATION
@@ -50,7 +50,7 @@
 /datum/preference/choiced/ear_variation/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	return TRUE
@@ -77,7 +77,7 @@
 /datum/preference/choiced/species_feature/felinid_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -109,7 +109,7 @@
 /datum/preference/choiced/species_feature/lizard_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -141,7 +141,7 @@
 /datum/preference/choiced/species_feature/fox_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -162,7 +162,7 @@
 /datum/preference/choiced/species_feature/dog_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -205,7 +205,7 @@
 /datum/preference/choiced/species_feature/flying_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -237,7 +237,7 @@
 /datum/preference/choiced/species_feature/monkey_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -269,7 +269,7 @@
 /datum/preference/choiced/species_feature/mammal_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -301,7 +301,7 @@
 /datum/preference/choiced/species_feature/fish_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -333,7 +333,7 @@
 /datum/preference/choiced/species_feature/humanoid_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)
@@ -365,7 +365,7 @@
 /datum/preference/choiced/species_feature/synthetic_ears/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[EARS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_EARS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/ear_variation)

--- a/local/code/modules/character_prefs/preferences/species_features/fluff.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/fluff.dm
@@ -28,7 +28,7 @@
 /datum/preference/toggle/fluff/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[FLUFF]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_FLUFF]))
 		return FALSE
 
 	return TRUE
@@ -52,7 +52,7 @@
 /datum/preference/choiced/species_feature/fluff/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[FLUFF]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_FLUFF]))
 		return FALSE
 
 	var/has_fluff = preferences.read_preference(/datum/preference/toggle/fluff)
@@ -67,7 +67,7 @@
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features["fluff"] && (type in GLOB.bodypart_allowed_species[FLUFF]))
+	if(target.dna.features["fluff"] && (type in GLOB.bodypart_allowed_species[FEATURE_FLUFF]))
 		if(target.dna.features["fluff"] != /datum/sprite_accessory/fluff/none::name && target.dna.features["fluff"] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/fluff)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)

--- a/local/code/modules/character_prefs/preferences/species_features/frills.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/frills.dm
@@ -37,7 +37,7 @@
 /datum/preference/toggle/frills/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[FRILLS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_FRILLS]))
 		return FALSE
 
 	return TRUE
@@ -61,7 +61,7 @@
 /datum/preference/choiced/species_feature/lizard_frills/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[FRILLS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_FRILLS]))
 		return FALSE
 
 	var/has_frills = preferences.read_preference(/datum/preference/toggle/frills)
@@ -94,7 +94,7 @@
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features[FEATURE_FRILLS] && (type in GLOB.bodypart_allowed_species[FRILLS]))
+	if(target.dna.features[FEATURE_FRILLS] && (type in GLOB.bodypart_allowed_species[FEATURE_FRILLS]))
 		if(target.dna.features[FEATURE_FRILLS] != /datum/sprite_accessory/frills/none::name && target.dna.features[FEATURE_FRILLS] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/frills)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)

--- a/local/code/modules/character_prefs/preferences/species_features/horns.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/horns.dm
@@ -79,14 +79,14 @@
 /datum/preference/toggle/horns/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[HORNS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_HORNS]))
 		return FALSE
 
 	return TRUE
 
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features[FEATURE_HORNS] && (type in GLOB.bodypart_allowed_species[HORNS]))
+	if(target.dna.features[FEATURE_HORNS] && (type in GLOB.bodypart_allowed_species[FEATURE_HORNS]))
 		if(target.dna.features[FEATURE_HORNS] != /datum/sprite_accessory/horns/none::name && target.dna.features[FEATURE_HORNS] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/horns)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -115,7 +115,7 @@
 /datum/preference/choiced/species_feature/lizard_horns/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[HORNS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_HORNS]))
 		return FALSE
 
 	var/has_horns = preferences.read_preference(/datum/preference/toggle/horns)

--- a/local/code/modules/character_prefs/preferences/species_features/snout.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/snout.dm
@@ -1,6 +1,6 @@
 /datum/species/regenerate_organs(mob/living/carbon/target, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE, replace_missing = TRUE)
 	. = ..()
-	if(target.dna.features[FEATURE_SNOUT] && (type in GLOB.bodypart_allowed_species[SNOUT]))
+	if(target.dna.features[FEATURE_SNOUT] && (type in GLOB.bodypart_allowed_species[FEATURE_SNOUT]))
 		if(target.dna.features[FEATURE_SNOUT] != /datum/sprite_accessory/snouts/none::name && target.dna.features[FEATURE_SNOUT] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/snout)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -27,7 +27,7 @@
 /datum/preference/toggle/snout/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[SNOUT]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_SNOUT]))
 		return FALSE
 
 	return TRUE
@@ -51,7 +51,7 @@
 /datum/preference/choiced/species_feature/lizard_snout/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[SNOUT]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_SNOUT]))
 		return FALSE
 
 	var/has_snout = preferences.read_preference(/datum/preference/toggle/snout)

--- a/local/code/modules/character_prefs/preferences/species_features/tail.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/tail.dm
@@ -172,6 +172,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_dog"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/dog_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == DOG_TYPE)	// we will be sharing the 'tail_other' slot with multiple tail types
@@ -209,6 +210,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_fox"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/fox_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == FOX_TYPE)
@@ -246,6 +248,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_mammal"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/mammal_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == MAMMAL_TYPE)
@@ -283,6 +286,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_flying"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/flying_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == FLYING_TYPE)
@@ -385,6 +389,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_synthetic"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/synth_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == CYBERNETIC_TYPE)
@@ -422,6 +427,7 @@
 	should_generate_icons = TRUE
 	main_feature_name = "Tail"
 	feature_key = "tail_humanoid"
+	priority = PREFERENCE_PRIORITY_PRE_SPECIES
 
 /datum/preference/choiced/species_feature/humanoid_tail/apply_to_human(mob/living/carbon/human/target, value)
 	if(target.dna.tail_type == HUMANOID_TYPE)

--- a/local/code/modules/character_prefs/preferences/species_features/tail.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/tail.dm
@@ -353,10 +353,6 @@
 	main_feature_name = "Tail"
 	feature_key = FEATURE_TAIL_FISH
 
-/datum/preference/choiced/species_feature/fish_tail/apply_to_human(mob/living/carbon/human/target, value)
-	if(target.dna.tail_type == AQUATIC_TYPE)
-		target.dna.features[FEATURE_TAIL_FISH] = value
-
 /datum/preference/choiced/species_feature/fish_tail/compile_constant_data()
 	var/list/data = ..()
 	data[SUPPLEMENTAL_FEATURE_KEY] = /datum/preference/tri_color/tail_color::savefile_key

--- a/local/code/modules/character_prefs/preferences/species_features/tail.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/tail.dm
@@ -18,23 +18,23 @@
 	if(!ishuman(target))
 		return
 
-	if(target.dna.features["tail_lizard"] != /datum/sprite_accessory/tails/lizard/none::name  && (type in GLOB.bodypart_allowed_species[TAIL]) && target.dna.features["tail_lizard"] != /datum/sprite_accessory/blank::name)
+	if(target.dna.features["tail_lizard"] != /datum/sprite_accessory/tails/lizard/none::name  && (type in GLOB.bodypart_allowed_species[FEATURE_TAIL]) && target.dna.features["tail_lizard"] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/lizard)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(target.dna.features["tail_cat"] != /datum/sprite_accessory/tails/felinid/none::name && (type in GLOB.bodypart_allowed_species[TAIL]) && target.dna.features["tail_cat"] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features["tail_cat"] != /datum/sprite_accessory/tails/felinid/none::name && (type in GLOB.bodypart_allowed_species[FEATURE_TAIL]) && target.dna.features["tail_cat"] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/cat)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(target.dna.features["tail_monkey"] != /datum/sprite_accessory/tails/monkey/none::name && (type in GLOB.bodypart_allowed_species[TAIL]) && target.dna.features["tail_monkey"] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features["tail_monkey"] != /datum/sprite_accessory/tails/monkey/none::name && (type in GLOB.bodypart_allowed_species[FEATURE_TAIL]) && target.dna.features["tail_monkey"] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/monkey)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if(target.dna.features["fish_tail"] != /datum/sprite_accessory/tails/fish/none::name && (type in GLOB.bodypart_allowed_species[TAIL]) && target.dna.features["fish_tail"] != /datum/sprite_accessory/blank::name)
+	else if(target.dna.features["fish_tail"] != /datum/sprite_accessory/tails/fish/none::name && (type in GLOB.bodypart_allowed_species[FEATURE_TAIL]) && target.dna.features["fish_tail"] != /datum/sprite_accessory/blank::name)
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/tail/fish)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 		return .
-	else if((target.dna.features["tail_other"] != /datum/sprite_accessory/tails/lizard/none::name && (type in GLOB.bodypart_allowed_species[TAIL]) && target.dna.features["tail_other"] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type != NO_VARIATION))
+	else if((target.dna.features["tail_other"] != /datum/sprite_accessory/tails/lizard/none::name && (type in GLOB.bodypart_allowed_species[FEATURE_TAIL]) && target.dna.features["tail_other"] != /datum/sprite_accessory/blank::name) && (target.dna.tail_type != NO_VARIATION))
 		var/obj/item/organ/organ_path = text2path("/obj/item/organ/tail/[target.dna.tail_type]")
 		var/obj/item/organ/replacement = SSwardrobe.provide_type(organ_path)
 		replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -98,7 +98,7 @@
 /datum/preference/choiced/tail_variation/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	return TRUE
@@ -126,7 +126,7 @@
 /datum/preference/choiced/species_feature/lizard_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -157,7 +157,7 @@
 /datum/preference/choiced/species_feature/tail_felinid/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
 	if(chosen_variation == CAT_TYPE)
@@ -192,7 +192,7 @@
 /datum/preference/choiced/species_feature/dog_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -229,7 +229,7 @@
 /datum/preference/choiced/species_feature/fox_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -266,7 +266,7 @@
 /datum/preference/choiced/species_feature/mammal_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -303,7 +303,7 @@
 /datum/preference/choiced/species_feature/flying_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -335,7 +335,7 @@
 /datum/preference/choiced/species_feature/monkey_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -368,7 +368,7 @@
 /datum/preference/choiced/species_feature/fish_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -405,7 +405,7 @@
 /datum/preference/choiced/species_feature/synth_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)
@@ -442,7 +442,7 @@
 /datum/preference/choiced/species_feature/humanoid_tail/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[TAIL]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_TAIL]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/tail_variation)

--- a/local/code/modules/character_prefs/preferences/species_features/wings.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/wings.dm
@@ -13,14 +13,14 @@
 	if(!ishuman(target))
 		return
 
-	if(target.dna.features["moth_wings"] && (type in GLOB.bodypart_allowed_species[WINGS]))
+	if(target.dna.features["moth_wings"] && (type in GLOB.bodypart_allowed_species[FEATURE_WINGS]))
 		if(target.dna.wing_type == NO_VARIATION)
 			return .
 		if((target.dna.features["moth_wings"] != /datum/sprite_accessory/moth_wings/none::name && target.dna.features["moth_wings"] != /datum/sprite_accessory/blank::name))
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/wings/moth)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 			return .
-	if(target.dna.features["wings"] && (type in GLOB.bodypart_allowed_species[WINGS]))
+	if(target.dna.features["wings"] && (type in GLOB.bodypart_allowed_species[FEATURE_WINGS]))
 		if(target.dna.features["wings"] != /datum/sprite_accessory/wings_anthro/none::name && target.dna.features["wings"] != /datum/sprite_accessory/blank::name)
 			var/obj/item/organ/replacement = SSwardrobe.provide_type(/obj/item/organ/wings/more)
 			replacement.Insert(target, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -58,7 +58,7 @@
 /datum/preference/choiced/wing_variation/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[WINGS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_WINGS]))
 		return FALSE
 
 	return TRUE
@@ -94,7 +94,7 @@
 /datum/preference/choiced/species_feature/wings/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[WINGS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_WINGS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/wing_variation)
@@ -118,7 +118,7 @@
 /datum/preference/choiced/species_feature/moth_wings/is_accessible(datum/preferences/preferences)
 	. = ..()
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!(species.type in GLOB.bodypart_allowed_species[WINGS]))
+	if(!(species.type in GLOB.bodypart_allowed_species[FEATURE_WINGS]))
 		return FALSE
 
 	var/chosen_variation = preferences.read_preference(/datum/preference/choiced/wing_variation)

--- a/local/code/modules/character_prefs/species/_species.dm
+++ b/local/code/modules/character_prefs/species/_species.dm
@@ -29,7 +29,7 @@
 //	Used for most races
 /datum/species/on_species_gain(mob/living/carbon/human/target, datum/species/old_species, pref_load, regenerate_icons = TRUE)
 	var/list/frame_bodyparts = target.dna.features["frame_list"]
-	if(!(type in GLOB.bodypart_allowed_species[CYBER_FRAME]))
+	if(!(type in GLOB.bodypart_allowed_species[FEATURE_CYBER_FRAME]))
 		return ..()
 	if(type == /datum/species/synth && frame_bodyparts && frame_bodyparts[BODY_ZONE_HEAD])
 		bodypart_overrides[BODY_ZONE_HEAD] = frame_bodyparts[BODY_ZONE_HEAD]


### PR DESCRIPTION

## About The Pull Request

Random smattering of fixes and a cleanup
- Changes feature defines in `code/__DEFINES/~effigy/mutants.dm` to all start with `FEATURE_`, removes ones that already exist
- Add a new preference priority (`PREFERENCE_PRIORITY_PRE_SPECIES`) after the default but before `PREFERENCE_PRIORITY_SPECIES`, needed because the tail and ear variation prefs need to apply before the tail and ear choices themselves (so `dna.tail/ear_type` is set to the right value) but before species is set (because that's when `regenerate_organs` is called)

## Why It's Good For The Game

Fixes bug with certain tail types and all ear types just not applying 

## Changelog
:cl:
fix: fixed certain tail/ear choices not properly being applied
/:cl:
