### PR TITLE
Fix overriding admin pre-game delay

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -204,8 +204,14 @@ SUBSYSTEM_DEF(ticker)
 				timeLeft = 0
 				CONFIG_SET(flag/setup_bypass_player_check, TRUE) // EffigyEdit Add - Custom Lobby
 
+			// EffigyEdit Add - Custom Lobby
+			if(timeLeft <= 0 && launch_queued && totalPlayersReady > 0)
+				SSticker.queue_game_start(94 SECONDS)
+				launch_queued = FALSE
+			// EffigyEdit Add End
+
 			//countdown
-			if(timeLeft < 0 && CONFIG_GET(flag/setup_bypass_player_check)) // EffigyEdit Change - Custom Lobby - Original: timeLeft < 0
+			if(timeLeft < 0 && !CONFIG_GET(flag/setup_bypass_player_check)) // EffigyEdit Change - Custom Lobby - Original: timeLeft < 0
 				return
 			timeLeft -= wait
 
@@ -233,10 +239,6 @@ SUBSYSTEM_DEF(ticker)
 			if(timeLeft <= 94 SECONDS && timeLeft > 0 && !hr_announce_fired && totalPlayersReady > 0 && !CONFIG_GET(flag/setup_bypass_player_check))
 				queue_game_start_announcement()
 				hr_announce_fired = TRUE
-
-			if(timeLeft <= 0 && launch_queued && totalPlayersReady > 0)
-				SSticker.queue_game_start(94 SECONDS)
-				launch_queued = FALSE
 			// EffigyEdit Add End
 
 			if(timeLeft <= 0)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -216,7 +216,7 @@ SUBSYSTEM_DEF(ticker)
 			timeLeft -= wait
 
 			// EffigyEdit Add - Custom Lobby
-			if(CONFIG_GET(flag/use_scheduled_lobby_track) && timeLeft <= lobby_track_duration && lobby_track_duration > 0 && !lobby_track_fired)
+			if(CONFIG_GET(flag/use_scheduled_lobby_track) && timeLeft <= lobby_track_duration && lobby_track_duration > 0 && !lobby_track_fired && totalPlayersReady > 0)
 				if(timeLeft >= lobby_track_duration - 4 SECONDS)
 					play_lobby_track(lobby_track_id)
 				lobby_track_fired = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes being able to bypass admin pre-game delay by toggling Ready.

## Changelog

:cl: LT3
fix: Fixed overriding admin delayed round start with the ready button
/:cl: