### PR TITLE
A few Rimpoint fixes

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -6706,6 +6706,7 @@
 /area/taeloth/underground)
 "cpU" = (
 /obj/structure/table,
+/obj/item/papercutter,
 /turf/open/floor/glass/reinforced,
 /area/station/cargo/sorting)
 "cqd" = (
@@ -22582,7 +22583,6 @@
 /area/station/hallway/secondary/exit/escape_pod)
 "hQW" = (
 /obj/structure/table,
-/obj/item/papercutter,
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 4
 	},

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -43026,6 +43026,10 @@
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /obj/item/storage/box/lights/mixed,
+/obj/machinery/status_display/supply{
+	dir = 4;
+	pixel_x = 32
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/lobby)
 "pfe" = (
@@ -54810,6 +54814,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
+"sXc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/status_display/supply{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "sXk" = (
 /turf/open/floor/iron/dark/side{
 	dir = 5
@@ -110642,7 +110656,7 @@ sBD
 vXL
 grc
 ylf
-jPA
+sXc
 uGU
 eog
 vGs

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -22590,10 +22590,10 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/item/stamp/denied,
 /obj/item/stamp/granted{
 	pixel_y = 8
 	},
-/obj/item/stamp/denied,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hQX" = (

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -23800,6 +23800,11 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay - Treatment Center, Northeast"
 	},
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -31202,6 +31207,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"kUo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/sink/directional/north,
+/turf/open/floor/wood/tile,
+/area/station/science/breakroom)
 "kUx" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/edge{
@@ -56740,7 +56752,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/corner,
-/obj/machinery/newscaster/directional/west,
+/obj/structure/sink/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/medical/pharmacy)
 "tJt" = (
@@ -59431,16 +59443,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/ai/satellite/foyer)
 "uEQ" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 5
 	},
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/storage/box/masks,
+/obj/structure/sink/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
@@ -96576,7 +96583,7 @@ fyJ
 gyy
 mBH
 dfw
-mBH
+kUo
 fyJ
 xCe
 wwq

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -8663,7 +8663,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/structure/sink/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
 "dbR" = (
@@ -48549,6 +48549,7 @@
 /area/station/tcommsat/server)
 "qWF" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/structure/sink/directional/south,
 /turf/open/floor/iron/diagonal,
 /area/station/science/robotics/augments)
 "qWR" = (
@@ -64555,6 +64556,7 @@
 /area/taeloth/nearstation/ai_sat_trail)
 "wpW" = (
 /obj/structure/table/reinforced,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
 "wpY" = (

--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -22590,6 +22590,10 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/item/stamp/granted{
+	pixel_y = 8
+	},
+/obj/item/stamp/denied,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hQX" = (


### PR DESCRIPTION

## About The Pull Request

- Adds GRANTED and DENIED stamps to cargo because there wasn't any
- Adds two cargo shuttle time displays to cargo
- Adds some sinks to chem, morgue, medbay, and science

## Why It's Good For The Game

Noticed it was missing some things

## Changelog
:cl:
map: added GRANTED/DENIED stamps to Rimpoint cargo
map: added two cargo shuttle displays to Rimpoint cargo
map: added a few sinks to Rimpoint medbay and science
/:cl:
