### PR TITLE
Fix lobby HUD hard deletes

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -803,13 +803,15 @@
 /atom/movable/screen/lobby/button/start_now/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker?.current_state > GAME_STATE_PREGAME)
-		qdel(src)
+		set_button_status(FALSE)
+		return
 
 	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(enter_pregame))
 
 /atom/movable/screen/lobby/button/start_now/proc/enter_pregame(source)
 	SIGNAL_HANDLER
-	qdel(src)
+	set_button_status(FALSE)
+	UnregisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING)
 // EffigyEdit Add End
 
 /atom/movable/screen/lobby/button/start_now/Click(location, control, params)
@@ -1051,7 +1053,8 @@
 /atom/movable/screen/lobby/loading_screen/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker?.current_state != GAME_STATE_STARTUP)
-		qdel(src)
+		icon = null
+		return
 
 	icon = SStitle.splash_turf.icon
 	icon_state = SStitle.splash_turf.icon_state
@@ -1059,7 +1062,8 @@
 
 /atom/movable/screen/lobby/loading_screen/proc/enter_pregame(source)
 	SIGNAL_HANDLER
-	qdel(src)
+	icon = null
+	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME)
 
 /atom/movable/screen/lobby/progress_bar
 	icon = 'local/icons/hud/lobby/loading.dmi'
@@ -1070,7 +1074,8 @@
 /atom/movable/screen/lobby/progress_bar/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker?.current_state != GAME_STATE_STARTUP)
-		qdel(src)
+		icon_state = null
+		return
 
 	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(enter_pregame))
 	RegisterSignal(SSdcs, COMSIG_SUBSYSTEM_INCREMENT_PROGRESS, PROC_REF(init_progress))
@@ -1081,7 +1086,8 @@
 	SIGNAL_HANDLER
 	if(hud.mymob)
 		winset(hud.mymob, "mapwindow.status_bar", "is-visible=true")
-	qdel(src)
+	icon_state = null
+	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME)
 
 /atom/movable/screen/lobby/progress_bar/proc/init_progress(source, new_progress)
 	SIGNAL_HANDLER
@@ -1097,13 +1103,15 @@
 /atom/movable/screen/lobby/fluff_text/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker?.current_state != GAME_STATE_STARTUP)
-		qdel(src)
+		maptext = null
+		return
 
 	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(enter_pregame))
 
 /atom/movable/screen/lobby/fluff_text/proc/enter_pregame(source)
 	SIGNAL_HANDLER
-	qdel(src)
+	maptext = null
+	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME)
 
 /atom/movable/screen/lobby/fluff_text/proc/init_progress(fluff_message)
 	maptext = "<span style='font-family: \"Chakra Petch\"; font-size: 12pt; line-height: 0.90; -dm-text-outline: 1px #22252f'>[fluff_message]</span>"


### PR DESCRIPTION

## About The Pull Request

These screen objects shouldn't be deleted early, they should be hidden until the HUD itself is deleted, at which point they get deleted with proper ref clean up

## Why It's Good For The Game

```
 - 	"/atom/movable/screen/lobby/fluff_text": {
 - 		"Failures": 7, 
 - 		"qdel() Count": 38, 
 - 		"Destroy() Cost (ms)": 0.762994, 
 - 		"Total Hard Deletes": 7, 
 - 		"Time Spend Hard Deleting (ms)": 1043.66, 
 - 		"Highest Time Spend Hard Deleting (ms)": 213.013
 - 	}, 
 - 	"/atom/movable/screen/lobby/progress_bar": {
 - 		"Failures": 7, 
 - 		"qdel() Count": 38, 
 - 		"Destroy() Cost (ms)": 0.813997, 
 - 		"Total Hard Deletes": 7, 
 - 		"Time Spend Hard Deleting (ms)": 908.418, 
 - 		"Highest Time Spend Hard Deleting (ms)": 199.497
 - 	}, 
 - 	"/atom/movable/screen/lobby/loading_screen": {
 - 		"Failures": 7, 
 - 		"qdel() Count": 38, 
 - 		"Destroy() Cost (ms)": 0.907995, 
 - 		"Total Hard Deletes": 7, 
 - 		"Time Spend Hard Deleting (ms)": 884.715, 
 - 		"Highest Time Spend Hard Deleting (ms)": 176.731
 - 	}, 
```

## Changelog

N/A