### PR TITLE
Add camera to Foxhole xenobio

### DIFF
--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -36704,6 +36704,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd","xeno")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
 "tIi" = (


### PR DESCRIPTION

## About The Pull Request

Xenobio on Foxhole was missing a camera near the freezer so you couldn't place slimes in it through the management console

## Why It's Good For The Game

Usability

## Changelog
:cl:
map: added a camera near the xenobio freezer on Foxhole
/:cl:
