### PR TITLE
Live editable tagline

### DIFF
--- a/code/_globalvars/~effigy/subsystem.dm
+++ b/code/_globalvars/~effigy/subsystem.dm
@@ -1,3 +1,7 @@
+// World
+GLOBAL_VAR(world_tagline)
+GLOBAL_PROTECT(world_tagline)
+
 // Initialization/Lobby Screen
 GLOBAL_LIST_EMPTY(init_message_clients)
 GLOBAL_VAR_INIT(init_progress, 0)

--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -77,7 +77,6 @@ SUBSYSTEM_DEF(persistence)
 	load_delamination_counter()
 	load_tram_counter()
 	load_adventures()
-	load_storyteller_type() // EffigyEdit Add - Storyteller
 	return SS_INIT_SUCCESS
 
 ///Collects all data to persist.

--- a/config/config.txt
+++ b/config/config.txt
@@ -663,8 +663,5 @@ GENERATE_ASSETS_IN_INIT
 ## Server short name on Hub entry
 # TAGLINE_NAME a generic TG-based server
 
-## Server tagline on Hub entry
-# TAGLINE_DESC
-
 ## Server URL on Hub entry
 # TAGLINE_URL

--- a/effigy.dme
+++ b/effigy.dme
@@ -6884,6 +6884,7 @@
 #include "local\code\controllers\subsystem\dynamic\dynamic_ruleset_midround.dm"
 #include "local\code\controllers\subsystem\dynamic\dynamic_ruleset_roundstart.dm"
 #include "local\code\controllers\subsystem\persistence\_persistence.dm"
+#include "local\code\controllers\subsystem\persistence\tagline.dm"
 #include "local\code\datums\blooper.dm"
 #include "local\code\datums\emotes.dm"
 #include "local\code\datums\ert.dm"

--- a/local/code/controllers/subsystem/persistence/_persistence.dm
+++ b/local/code/controllers/subsystem/persistence/_persistence.dm
@@ -1,11 +1,35 @@
+#define STORYTELLER_LAST_FILEPATH "data/storyteller_last_round.txt"
+
+/*
+### PERSISTENCE SUBSYSTEM TRACKING BELOW ###
+Basically, this keeps track of what we voted last time to prevent it being voted on again.
+For this, we use the SSpersistence.last_storyteller_type variable
+
+We then just check what the last one is in SSgamemode.storyteller_vote_choices()
+*/
+
 /datum/controller/subsystem/persistence
 	var/last_storyteller_type = ""
 
-/// Saves the persistence data for the owner.
-/mob/living/carbon/human/proc/save_individual_persistence(var/ckey)
-	return
-	/* EffigyEdit TODO: confirm if required
-	var/obj/item/organ/internal/brain/brain = get_organ_slot(ORGAN_SLOT_BRAIN)
+/datum/controller/subsystem/persistence/Initialize()
+	. = ..()
+	load_storyteller_type()
+	load_tagline()
 
-	return brain?.modular_persistence?.save_data(ckey)
-	*/
+/// Extends collect_data
+/datum/controller/subsystem/persistence/collect_data()
+	. = ..()
+	collect_storyteller_type()
+	save_tagline()
+
+/// Loads last storyteller into last_storyteller_type
+/datum/controller/subsystem/persistence/proc/load_storyteller_type()
+	if(!fexists(STORYTELLER_LAST_FILEPATH))
+		return
+	last_storyteller_type = text2num(file2text(STORYTELLER_LAST_FILEPATH))
+
+/// Collects current storyteller and stores it
+/datum/controller/subsystem/persistence/proc/collect_storyteller_type()
+	rustg_file_write("[SSgamemode.storyteller.storyteller_type]", STORYTELLER_LAST_FILEPATH)
+
+#undef STORYTELLER_LAST_FILEPATH

--- a/local/code/controllers/subsystem/persistence/tagline.dm
+++ b/local/code/controllers/subsystem/persistence/tagline.dm
@@ -1,0 +1,27 @@
+#define TAGLINE_FILEPATH "data/world_tagline.txt"
+
+/// Loads tagline into GLOB.world_tagline for Hub entry
+/datum/controller/subsystem/persistence/proc/load_tagline()
+	if(!fexists(TAGLINE_FILEPATH))
+		return
+	GLOB.world_tagline = file2text(TAGLINE_FILEPATH)
+	log_game("Server tagline is: [GLOB.world_tagline]")
+	world.update_status()
+
+/// Saves tagline
+/datum/controller/subsystem/persistence/proc/save_tagline()
+	rustg_file_write("[GLOB.world_tagline]", TAGLINE_FILEPATH)
+
+#undef TAGLINE_FILEPATH
+
+ADMIN_VERB(update_tagline, R_SERVER, "Update Server Tagline", "Update the server tagline displayed on Hub entry.", ADMIN_CATEGORY_SERVER)
+	var/new_tagline = tgui_input_text(user, "How do you want to present yourself to the world?", "Update Tagline", max_length = 112)
+	if(isnull(new_tagline))
+		if(tgui_alert(user, "Are you cancelling your action, or do you want to clear the tagline?", "Update Tagline", list("Cancel", "Clear Tagline")) != "Clear Tagline")
+			return
+
+	GLOB.world_tagline = new_tagline
+	log_admin_private("Admin [key_name_admin(user)] has updated the server tagline to: [new_tagline]")
+	log_game("Server tagline is: [GLOB.world_tagline]")
+	message_admins("Admin [key_name_admin(user)] has updated the server tagline to: [new_tagline]")
+	BLACKBOX_LOG_ADMIN_VERB("Update Server Tagline")

--- a/local/code/game/machinery/cryopod.dm
+++ b/local/code/game/machinery/cryopod.dm
@@ -257,10 +257,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 				if(isnull(stored_ckey))
 					stored_ckey = mob_occupant.mind.key // if mob does not have a ckey and was placed in cryo by someone else, we can get the key this way
 
-		var/mob/living/carbon/human/human_occupant = occupant
-		if(istype(human_occupant) && human_occupant.mind)
-			human_occupant.save_individual_persistence(stored_ckey)
-
 		COOLDOWN_START(src, despawn_world_time, time_till_despawn)
 
 /obj/machinery/cryopod/open_machine(drop = TRUE, density_to_set = FALSE)

--- a/local/code/game/world.dm
+++ b/local/code/game/world.dm
@@ -1,7 +1,7 @@
 /world/update_status()
 	var/features
 	var/discord = CONFIG_GET(string/discordlink)
-	var/new_status = "<a href=\"[CONFIG_GET(string/tagline_url)]\"><b>[CONFIG_GET(string/tagline_name)]</b></a>] [discord ? "\[<a href=\"[discord]\">Discord</a>\]" : ""]<br/>\[[CONFIG_GET(string/tagline_desc)]]<br/>"
+	var/new_status = "<a href=\"[CONFIG_GET(string/tagline_url)]\"><b>[CONFIG_GET(string/tagline_name)]</b></a>] [discord ? "\[<a href=\"[discord]\">Discord</a>\]" : ""]<br/>\[[GLOB.world_tagline]]<br/>"
 
 	if(SSmapping.current_map)
 		features += "\[Map: <b>[SSmapping.current_map.map_name]</b>]"

--- a/local/code/modules/character_prefs/preferences/species_features/brain.dm
+++ b/local/code/modules/character_prefs/preferences/species_features/brain.dm
@@ -34,11 +34,6 @@
 
 	new_brain = new new_brain()
 
-/* Need variant for this
-	new_brain.modular_persistence = old_brain.modular_persistence
-	old_brain.modular_persistence = null
-*/
-
 	new_brain.Insert(target, movement_flags = DELETE_IF_REPLACED)
 
 	// Prefs can be applied to mindless mobs, let's not try to move the non-existent mind back in!

--- a/local/code/modules/storyteller/storyteller_vote.dm
+++ b/local/code/modules/storyteller/storyteller_vote.dm
@@ -40,30 +40,3 @@
 /datum/vote/storyteller/finalize_vote(winning_option)
 	SSgamemode.storyteller_vote_result(winning_option)
 	SSgamemode.storyteller_voted = TRUE
-
-/*
-### PERSISTENCE SUBSYSTEM TRACKING BELOW ###
-Basically, this keeps track of what we voted last time to prevent it being voted on again.
-For this, we use the SSpersistence.last_storyteller_type variable
-
-We then just check what the last one is in SSgamemode.storyteller_vote_choices()
-*/
-
-#define STORYTELLER_LAST_FILEPATH "data/storyteller_last_round.txt"
-
-/// Extends collect_data
-/datum/controller/subsystem/persistence/collect_data()
-	. = ..()
-	collect_storyteller_type()
-
-/// Loads last storyteller into last_storyteller_type
-/datum/controller/subsystem/persistence/proc/load_storyteller_type()
-	if(!fexists(STORYTELLER_LAST_FILEPATH))
-		return
-	last_storyteller_type = text2num(file2text(STORYTELLER_LAST_FILEPATH))
-
-/// Collects current storyteller and stores it
-/datum/controller/subsystem/persistence/proc/collect_storyteller_type()
-	rustg_file_write("[SSgamemode.storyteller.storyteller_type]", STORYTELLER_LAST_FILEPATH)
-
-#undef STORYTELLER_LAST_FILEPATH


### PR DESCRIPTION
## About The Pull Request

Restores live editable server tagline from old base. Configured via admin verb.
Moves storyteller persistence load/save to modular override.
Removes some unused persistence brain code

## Changelog

:cl: LT3
admin: Admins with +SERVER can change the server hub tagline
/:cl: