### PR TITLE
Add lidocaine bottle to advanced surgery tray subtype

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -225,6 +225,7 @@
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/stack/sticky_tape/surgical,
 		/obj/item/clothing/mask/surgical,
+		/obj/item/storage/pill_bottle/lidocaine, // EffigyEdit Add
 	)
 
 /obj/effect/spawner/surgery_tray


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

It's in the base one

## Changelog

:cl:
qol: lidocaine now spawns in runtimestation surgical tray
/:cl:
