### PR TITLE
Fix incorrect pump on FoxholeStation

### DIFF
--- a/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
+++ b/_maps/effigy/map_files/FoxHoleStation/foxholestation.dmm
@@ -8970,10 +8970,10 @@
 /area/station/medical/break_room)
 "eMQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump/on/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump/on/general/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "eNw" = (


### PR DESCRIPTION

## About The Pull Request

Pump joining two different colored networks wasn't omni so wasn't connecting

## Why It's Good For The Game

air 

## Changelog
:cl:
map: Fixed Foxhole air pump
/:cl:
