### PR TITLE
Fix crew manifest button not showing in lobby

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -544,6 +544,7 @@
 	screen_loc = "TOP:-122,CENTER:+2"
 	name = "Observe"
 	*/
+	enabled = null // set in init
 	name = "Crew Manifest"
 	icon = 'local/icons/hud/lobby/lobby_315x32.dmi'
 	icon_state = "button_disabled"
@@ -564,7 +565,6 @@
 /atom/movable/screen/lobby/button/bottom/crew_manifest/proc/show_manifest_button()
 	SIGNAL_HANDLER
 	set_button_status(TRUE)
-	maptext = enabled_maptext
 	UnregisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING)
 // EffigyEdit Add End
 


### PR DESCRIPTION

## About The Pull Request

`enabled` defaults to `TRUE` on the button type meaning in `Initialize` the call to `set_button_status(TRUE)` early returns without setting maptext if you connect after round start. Also removed a redundant assignment

## Why It's Good For The Game

no secret buttons

## Changelog
:cl:
fix: fixed title screen crew manifest button sometimes not appearing
/:cl:
