### PR TITLE
Re-add lidocaine/sterilizine to NanoDrug Plus

### DIFF
--- a/local/code/modules/vending/medical.dm
+++ b/local/code/modules/vending/medical.dm
@@ -2,3 +2,9 @@
 	effigy_products = list(
 		/obj/item/ttsdevice = 3,
 	)
+
+/obj/machinery/vending/drugs
+	effigy_products = list(
+		/obj/item/storage/pill_bottle/lidocaine = 5,
+		/obj/item/reagent_containers/medigel/sterilizine = 5,
+	)


### PR DESCRIPTION
Closes https://github.com/effigy-se/effigy/issues/260

## Changelog

:cl: LT3
fix: Lidocaine is again available in the NanoDrug Plus
/:cl: