### PR TITLE
FIx pixel shifting not allowing you to pass mobs

### DIFF
--- a/code/__DEFINES/~effigy/living.dm
+++ b/code/__DEFINES/~effigy/living.dm
@@ -1,1 +1,0 @@
-#define COMPONENT_LIVING_PASSABLE (1<<0)

--- a/code/__DEFINES/~effigy/signals.dm
+++ b/code/__DEFINES/~effigy/signals.dm
@@ -26,6 +26,7 @@
 #define COMSIG_LIVING_RESET_PULL_OFFSETS "living_reset_pull_offsets"
 //from base of living/CanAllowThrough(): (atom/movable/mover, border_dir)
 #define COMSIG_LIVING_CAN_ALLOW_THROUGH "living_can_allow_through"
+	#define COMPONENT_LIVING_PASSABLE (1<<0)
 
 //when a character name is changed
 #define COMSIG_PREFERENCES_NAME_APPLIED "preferences_name_applied"

--- a/effigy.dme
+++ b/effigy.dme
@@ -441,7 +441,6 @@
 #include "code\__DEFINES\~effigy\layers.dm"
 #include "code\__DEFINES\~effigy\light.dm"
 #include "code\__DEFINES\~effigy\liquids.dm"
-#include "code\__DEFINES\~effigy\living.dm"
 #include "code\__DEFINES\~effigy\logging.dm"
 #include "code\__DEFINES\~effigy\maps.dm"
 #include "code\__DEFINES\~effigy\mobs.dm"

--- a/local/code/datums/components/pixel_shift_component.dm
+++ b/local/code/datums/components/pixel_shift_component.dm
@@ -87,7 +87,7 @@
 /// Checks if the parent is considered passthroughable from a direction. Projectiles will ignore the check and hit.
 /datum/component/pixel_shift/proc/check_passable(mob/source, atom/movable/mover, border_dir)
 	SIGNAL_HANDLER
-	if(!isprojectile(mover) && !mover.throwing && passthroughable & border_dir)
+	if(!isprojectile(mover) && !mover.throwing && (passthroughable & border_dir))
 		return COMPONENT_LIVING_PASSABLE
 
 /// Activates Pixel Shift on Keybind down. Only Pixel Shift movement will be allowed.

--- a/local/code/modules/mob/living/living.dm
+++ b/local/code/modules/mob/living/living.dm
@@ -5,3 +5,8 @@
 /mob/living/reset_pull_offsets(mob/living/pull_target, override)
 	. = ..()
 	SEND_SIGNAL(pull_target, COMSIG_LIVING_RESET_PULL_OFFSETS)
+
+/mob/living/CanAllowThrough(atom/movable/mover, border_dir)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_CAN_ALLOW_THROUGH, mover, border_dir) & COMPONENT_LIVING_PASSABLE)
+		return TRUE
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Turns out the signal never got sent whoops

## Why It's Good For The Game

Fixes #262 

## Changelog
:cl:
fix: fixed not being able to pass pixel shifted mobs without bumping them
/:cl:
