### PR TITLE
Fix both rotate buttons in character setup doing the same thing

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			remove_current_slot()
 			return TRUE
 		if ("rotate")
-			character_preview_view.setDir(turn(character_preview_view.dir, -90))
+			character_preview_view.setDir(turn(character_preview_view.dir, params["ccw"] ? 90 : -90)) // EffigyEdit Change - Two rotate buttons in character setup
 			return TRUE
 		if ("set_preference")
 			var/requested_preference_key = params["preference"]

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/EffigyPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/EffigyPreferences/MainPage.tsx
@@ -46,7 +46,7 @@ const CLOTHING_SELECTION_WIDTH = 8.3;
 const CLOTHING_SELECTION_MULTIPLIER = 4.3;
 
 type CharacterControlsProps = {
-  handleRotate: () => void;
+  handleRotate: (ccw: boolean) => void;
   handleOpenSpecies: () => void;
   gender: Gender;
   setGender: (gender: Gender) => void;
@@ -60,7 +60,7 @@ function CharacterControls(props: CharacterControlsProps) {
     <Stack>
       <Stack.Item>
         <Button
-          onClick={props.handleRotate}
+          onClick={() => props.handleRotate(true)}
           fontSize="22px"
           icon="undo"
           tooltip="Rotate"
@@ -70,7 +70,7 @@ function CharacterControls(props: CharacterControlsProps) {
 
       <Stack.Item>
         <Button
-          onClick={props.handleRotate}
+          onClick={() => props.handleRotate(false)}
           fontSize="22px"
           icon="redo"
           tooltip="Rotate"
@@ -683,8 +683,10 @@ export function MainPage(props: MainPageProps) {
               <CharacterControls
                 gender={data.character_preferences.misc.gender}
                 handleOpenSpecies={props.openSpecies}
-                handleRotate={() => {
-                  act('rotate');
+                handleRotate={(value) => {
+                  act('rotate', {
+                    ccw: value,
+                  });
                 }}
                 setGender={createSetPreference(act, 'gender')}
                 showGender={


### PR DESCRIPTION

## About The Pull Request

We got two buttons with different directions but they both do the same direction

## Why It's Good For The Game

Do the thing

## Changelog
:cl:
fix: fixed both rotate buttons in character setup doing the same thing
/:cl:
