### PR TITLE
Add role assignment channel to new game notification

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -151,7 +151,8 @@ SUBSYSTEM_DEF(ticker)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
 			for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
-				send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag)
+			//	send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag) // EffigyEdit Change - New Round Discord Notification
+				send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)
 			current_state = GAME_STATE_PREGAME
 			// EffigyEdit Add - Storyteller
 			GLOB.init_message_clients = null

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -152,7 +152,7 @@ SUBSYSTEM_DEF(ticker)
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
 			for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
 			//	send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag) // EffigyEdit Change - New Round Discord Notification
-				send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)
+				send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/role_announce_new_game) ? " <@&[CONFIG_GET(string/role_announce_new_game)]>" : ""][CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)
 			current_state = GAME_STATE_PREGAME
 			// EffigyEdit Add - Storyteller
 			GLOB.init_message_clients = null

--- a/config/config.txt
+++ b/config/config.txt
@@ -668,3 +668,6 @@ GENERATE_ASSETS_IN_INIT
 
 ## Channel on the Discord where people can self-assign roles
 # DISCORD_ROLES_CHANNEL_ID
+
+## Discord role ID to notify about a new game starting
+# ROLE_ANNOUNCE_NEW_GAME

--- a/config/config.txt
+++ b/config/config.txt
@@ -665,3 +665,6 @@ GENERATE_ASSETS_IN_INIT
 
 ## Server URL on Hub entry
 # TAGLINE_URL
+
+## Channel on the Discord where people can self-assign roles
+# DISCORD_ROLES_CHANNEL_ID

--- a/local/code/controllers/configuration/entries/general.dm
+++ b/local/code/controllers/configuration/entries/general.dm
@@ -16,6 +16,9 @@
 /datum/config_entry/string/discord_roles_channel_id
 	default = ""
 
+/datum/config_entry/string/role_announce_new_game
+	default = ""
+
 /// manifest preview in pre-lobby
 /datum/config_entry/flag/show_manifest_preview
 	default = TRUE

--- a/local/code/controllers/configuration/entries/general.dm
+++ b/local/code/controllers/configuration/entries/general.dm
@@ -13,6 +13,9 @@
 /datum/config_entry/string/discordlink
 	default = ""
 
+/datum/config_entry/string/discord_roles_channel_id
+	default = ""
+
 /// manifest preview in pre-lobby
 /datum/config_entry/flag/show_manifest_preview
 	default = TRUE


### PR DESCRIPTION
## About The Pull Request

Re-adds notifying a discord role about new game starts.

## Changelog

:cl: LT3
add: Players can add a Discord role to receive new game notifications
/:cl:
