### PR TITLE
Config to automatically reboot after idle TGS deployment

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -58,6 +58,7 @@ SUBSYSTEM_DEF(ticker)
 	var/roundend_check_paused = FALSE
 
 	var/round_start_time = 0
+	var/utc_init_time = 0 // EffigyEdit Add
 	var/list/round_start_events
 	var/list/round_end_events
 	var/mode_result = "undefined"
@@ -154,7 +155,8 @@ SUBSYSTEM_DEF(ticker)
 			//	send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag) // EffigyEdit Change - New Round Discord Notification
 				send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/role_announce_new_game) ? " <@&[CONFIG_GET(string/role_announce_new_game)]>" : ""][CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)
 			current_state = GAME_STATE_PREGAME
-			// EffigyEdit Add - Storyteller
+			// EffigyEdit Add - Storyteller and TGS
+			utc_init_time = REALTIMEOFDAY
 			GLOB.init_message_clients = null
 			var/storyteller = CONFIG_GET(string/default_storyteller)
 			if(storyteller)
@@ -177,11 +179,6 @@ SUBSYSTEM_DEF(ticker)
 					++totalPlayersReady
 					if(player.client?.holder)
 						++total_admins_ready
-
-			// EffigyEdit Add - Custom Lobby
-			if(timeLeft == COUNTDOWN_GAME_INIT)
-				return // server isn't finished init
-			// EffigyEdit Add End
 
 			if(start_immediately)
 				timeLeft = 0

--- a/code/datums/tgs_event_handler.dm
+++ b/code/datums/tgs_event_handler.dm
@@ -22,6 +22,7 @@
 		if(TGS_EVENT_DEPLOYMENT_COMPLETE)
 			message_admins("TGS: Deployment complete!")
 			to_chat(world, alert_boxed_message(PURPLE, "Server updated! Changes will be applied on the next round...")) // EffigyEdit Change - TGS Messages
+			post_deployment_restart() // EffigyEdit Add - TGS Messages
 		if(TGS_EVENT_WATCHDOG_DETACH)
 			message_admins("TGS restarting...")
 			reattach_timer = addtimer(CALLBACK(src, PROC_REF(LateOnReattach)), 1 MINUTES, TIMER_STOPPABLE)

--- a/config/config.txt
+++ b/config/config.txt
@@ -671,3 +671,6 @@ GENERATE_ASSETS_IN_INIT
 
 ## Discord role ID to notify about a new game starting
 # ROLE_ANNOUNCE_NEW_GAME
+
+## Automatically reboot after a TGS deployment if the server is idle
+# REBOOT_ON_IDLE_DEPLOYMENT

--- a/effigy.dme
+++ b/effigy.dme
@@ -6939,6 +6939,7 @@
 #include "local\code\datums\mind.dm"
 #include "local\code\datums\quirk.dm"
 #include "local\code\datums\scream_type.dm"
+#include "local\code\datums\tgs_event_handler.dm"
 #include "local\code\datums\actions\mobs\sing_tones.dm"
 #include "local\code\datums\ai_laws\laws_station_sided.dm"
 #include "local\code\datums\atmosphere\planetary.dm"

--- a/local/code/controllers/configuration/entries/general.dm
+++ b/local/code/controllers/configuration/entries/general.dm
@@ -25,6 +25,9 @@
 
 /datum/config_entry/flag/setup_bypass_player_check
 
+/// if server is idle, automatically reboot after a TGS deployment
+/datum/config_entry/flag/reboot_on_idle_deployment
+
 /// File where fluff status messages are stored
 /datum/config_entry/string/fluff_status_file
 	default = "config/effigy_splash_fluff.txt"

--- a/local/code/controllers/configuration/entries/general.dm
+++ b/local/code/controllers/configuration/entries/general.dm
@@ -25,7 +25,7 @@
 
 /datum/config_entry/flag/setup_bypass_player_check
 
-/// if server is idle, automatically reboot after a TGS deployment
+/// Automatically reboot after a TGS deployment if the server is idle
 /datum/config_entry/flag/reboot_on_idle_deployment
 
 /// File where fluff status messages are stored

--- a/local/code/datums/tgs_event_handler.dm
+++ b/local/code/datums/tgs_event_handler.dm
@@ -1,0 +1,15 @@
+/// Reboots the server after a TGS deployment. Requires config flag to be enabled. Server will only reboot if it's been idle for 2 hours.
+/datum/tgs_event_handler/impl/proc/post_deployment_restart()
+	if(!CONFIG_GET(flag/reboot_on_idle_deployment))
+		return
+
+	if(SSticker.current_state != GAME_STATE_PREGAME)
+		return  // We only care if there's no active round
+
+	if(SSticker.timeLeft != -20)
+		return
+
+	if((REALTIMEOFDAY - SSticker.utc_init_time) < 2 HOURS)
+		return
+
+	SSticker.Reboot("TGS Deployment: New Game Version", "pregame", 15 SECONDS)

--- a/local/code/datums/tgs_event_handler.dm
+++ b/local/code/datums/tgs_event_handler.dm
@@ -12,4 +12,4 @@
 	if((REALTIMEOFDAY - SSticker.utc_init_time) < 2 HOURS)
 		return
 
-	SSticker.Reboot("TGS Deployment: New Game Version", "pregame", 15 SECONDS)
+	SSticker.Reboot("TGS Deployment: New Game Version", "pregame", 4 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Adds a config flag to have the server automatically reboot into the newly deployed game version if the server has been idle for more than 2 hours.

## Why It's Good For The Game

Game automatically loads into new deployed version

## Changelog

:cl: LT3
config: Server can now automatically reboot after a TGS deployment
/:cl:
