### PR TITLE
Discord notification improvements and admin trigger

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -151,12 +151,14 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
+			/* EffigyEdit Remove - New Round Discord Notification
 			for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
-			//	send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag) // EffigyEdit Change - New Round Discord Notification
-				send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/role_announce_new_game) ? " <@&[CONFIG_GET(string/role_announce_new_game)]>" : ""][CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)
+				send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), channel_tag)
+			*/// EffigyEdit Remove End
 			current_state = GAME_STATE_PREGAME
 			// EffigyEdit Add - Storyteller and TGS
 			utc_init_time = REALTIMEOFDAY
+			announce_new_round_to_discord()
 			GLOB.init_message_clients = null
 			var/storyteller = CONFIG_GET(string/default_storyteller)
 			if(storyteller)

--- a/local/code/controllers/subsystem/persistence/_persistence.dm
+++ b/local/code/controllers/subsystem/persistence/_persistence.dm
@@ -21,6 +21,7 @@ We then just check what the last one is in SSgamemode.storyteller_vote_choices()
 	. = ..()
 	collect_storyteller_type()
 	save_tagline()
+	text2file("PERSISTENT_END_OF_ROUND", "data/previous_round_end_status.txt")
 
 /// Loads last storyteller into last_storyteller_type
 /datum/controller/subsystem/persistence/proc/load_storyteller_type()

--- a/local/code/controllers/subsystem/ticker.dm
+++ b/local/code/controllers/subsystem/ticker.dm
@@ -49,8 +49,9 @@
 /// Announces a new round to Discord, but only if the previous round completed normally.
 /// Checks for a flag file written by SSpersistence.collect_data() at round end.
 /datum/controller/subsystem/ticker/proc/announce_new_round_to_discord(admin_forced = FALSE)
-	if(!fexists("data/previous_round_end_status.txt"))
-		return
-	fdel("data/previous_round_end_status.txt")
+	if(!admin_forced)
+		if(!fexists("data/previous_round_end_status.txt"))
+			return
+		fdel("data/previous_round_end_status.txt")
 	for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
 		send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/role_announce_new_game) ? " <@&[CONFIG_GET(string/role_announce_new_game)]>" : ""][CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)

--- a/local/code/controllers/subsystem/ticker.dm
+++ b/local/code/controllers/subsystem/ticker.dm
@@ -45,3 +45,12 @@
 	to_chat(world, finalized_announcement)
 	for(var/mob/player in GLOB.player_list)
 		SEND_SOUND(player, sound('sound/announcer/default/attention.ogg'))
+
+/// Announces a new round to Discord, but only if the previous round completed normally.
+/// Checks for a flag file written by SSpersistence.collect_data() at round end.
+/datum/controller/subsystem/ticker/proc/announce_new_round_to_discord(admin_forced = FALSE)
+	if(!fexists("data/previous_round_end_status.txt"))
+		return
+	fdel("data/previous_round_end_status.txt")
+	for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
+		send2chat(new /datum/tgs_message_content("Round **[GLOB.round_id]** starting on **[SSmapping.current_map.map_name]!**[CONFIG_GET(string/role_announce_new_game) ? " <@&[CONFIG_GET(string/role_announce_new_game)]>" : ""][CONFIG_GET(string/discord_roles_channel_id) ? "\nTo opt-in for new game notifications, go to <#[CONFIG_GET(string/discord_roles_channel_id)]> and assign yourself the role." : ""]"), channel_tag)

--- a/local/code/modules/admin/verbs/server.dm
+++ b/local/code/modules/admin/verbs/server.dm
@@ -1,15 +1,9 @@
-/datum/admins/proc/announce_round_discord()
-	set category = "Server"
-	set desc = "Manually send a new round Discord announcement."
-	set name = "Announce Round to Discord"
+ADMIN_VERB(discord_notification, R_ADMIN, "Discord Round Notification", "Manually send a new round Discord announcement.", ADMIN_CATEGORY_SERVER)
 	SSticker.announce_new_round_to_discord(admin_forced = TRUE)
 	log_admin("[key_name(usr)] manually triggered a Discord round announcement.")
 	message_admins("[key_name_admin(usr)] manually triggered a Discord round announcement.")
 
-/datum/admins/proc/toggledchat()
-	set category = "Server"
-	set desc = "Toggle dis bitch"
-	set name = "Toggle Dead Chat"
+ADMIN_VERB(toggle_dead_chat, R_ADMIN, "Toggle Dead Chat", "Toggle dis bitch", ADMIN_CATEGORY_SERVER)
 	toggle_dchat()
 	log_admin("[key_name(usr)] toggled dead chat.")
 	message_admins("[key_name_admin(usr)] toggled dead chat.")

--- a/local/code/modules/admin/verbs/server.dm
+++ b/local/code/modules/admin/verbs/server.dm
@@ -1,3 +1,11 @@
+/datum/admins/proc/announce_round_discord()
+	set category = "Server"
+	set desc = "Manually send a new round Discord announcement."
+	set name = "Announce Round to Discord"
+	SSticker.announce_new_round_to_discord(admin_forced = TRUE)
+	log_admin("[key_name(usr)] manually triggered a Discord round announcement.")
+	message_admins("[key_name_admin(usr)] manually triggered a Discord round announcement.")
+
 /datum/admins/proc/toggledchat()
 	set category = "Server"
 	set desc = "Toggle dis bitch"


### PR DESCRIPTION
## About The Pull Request
Adjusts the discord announcement so only rounds that ended normally trigger an announcement, so that new round announcements don't erroneously notify players when someone's just doing restarts or whatever.

Admins can manually trigger the notification if they want.

## Changelog

:cl: LT3
admin: Admins can manually trigger new round notification
/:cl: