### PR TITLE
Fix RETA airlock overlay

### DIFF
--- a/local/code/game/machinery/doors/airlock.dm
+++ b/local/code/game/machinery/doors/airlock.dm
@@ -142,7 +142,7 @@
 			else
 				var/active_reta = has_active_reta_access()
 				if(active_reta)
-					light_state = "[AIRLOCK_LIGHT_RETA]_[active_reta]"
+					light_state = "[AIRLOCK_LIGHT_RETA]_[lowertext(active_reta)]"
 					if(active_reta == "Medical")
 						new_light_power = AIRLOCK_LIGHT_POWER_HIGH
 						new_light_color = COLOR_EFFIGY_SKY_BLUE

--- a/local/code/game/machinery/doors/airlock.dm
+++ b/local/code/game/machinery/doors/airlock.dm
@@ -142,7 +142,7 @@
 			else
 				var/active_reta = has_active_reta_access()
 				if(active_reta)
-					light_state = "[AIRLOCK_LIGHT_RETA]_[lowertext(active_reta)]"
+					light_state = "[AIRLOCK_LIGHT_RETA]_[LOWER_TEXT(active_reta)]"
 					if(active_reta == "Medical")
 						new_light_power = AIRLOCK_LIGHT_POWER_HIGH
 						new_light_color = COLOR_EFFIGY_SKY_BLUE


### PR DESCRIPTION
## About The Pull Request

Fixes missing RETA airlock overlay

## Changelog

:cl: LT3
fix: Airlocks properly show active RETA status
/:cl: