### PR TITLE
Fix airlocks flickering invisible when playing the deny animation

### DIFF
--- a/local/code/game/machinery/doors/airlock.dm
+++ b/local/code/game/machinery/doors/airlock.dm
@@ -197,6 +197,7 @@
 			new_light_power = AIRLOCK_LIGHT_POWER_HIGH
 			new_light_range = AIRLOCK_LIGHT_RANGE_LOW
 
+	. += get_airlock_overlay(frame_state, icon, src, em_block = TRUE)
 	if(airlock_material)
 		. += get_airlock_overlay("[airlock_material]_[frame_state]", overlays_file, src, em_block = TRUE)
 	else


### PR DESCRIPTION

## About The Pull Request

TG code has airlocks add an overlay that's just the base sprite, this hides them going invisible for <1 second when the airlock deny animation plays because the icon state gets changed to "deny" which doesn't exist, but it's covered up by the identical overlay. We didn't do this, now we do. That's all there is to say on the matter.

## Why It's Good For The Game

Fix bug

## Changelog
:cl:
fix: fixed airlocks going invisible for a split second when playing the access denied animation
/:cl:
