### PR TITLE
Fix TGUI spritesheet icons being offset

### DIFF
--- a/tgui/packages/tgui/styles/base.scss
+++ b/tgui/packages/tgui/styles/base.scss
@@ -9,7 +9,7 @@
 
 @use 'sass:math';
 
-$unit: 14px; // EffigyEdit Change - TGUI - Original: 12px
+$unit: 12px;
 $font-size: 1 * $unit !default;
 
 @function em($px) {

--- a/tgui/packages/tgui/styles/effigy/effigy-values.scss
+++ b/tgui/packages/tgui/styles/effigy/effigy-values.scss
@@ -10,7 +10,6 @@
  */
 :root {
   /* Font */
-  --font-size: 14px;
   --font-family: 'Chakra Petch', Geneva, sans-serif;
   --font-family-mono: 'Ubunto Mono', Consolas, monospace;
 
@@ -36,4 +35,9 @@
   --cursor-s-resize: s-resize;
   --cursor-se-resize: se-resize;
   --cursor-e-resize: e-resize;
+}
+
+body {
+  /* Defined on body not :root because of rem calculations */
+  --font-size: 14px;
 }


### PR DESCRIPTION

## About The Pull Request

using a root font size other than 12 caused problems in calculations that relied on `rem`, it turns out we can just override font size on body instead and its functionally indistinguishable, except these icons dont get stretched and offset anymore

## Why It's Good For The Game

Fixes #113 

## Changelog
:cl:
fix: fixed certain sprites in TGUI being misaligned
/:cl:
