### PR TITLE
Fix some tails that shouldn't have tail spines

### DIFF
--- a/local/code/modules/character_prefs/sprite_accessories/tails/tails_lizard.dm
+++ b/local/code/modules/character_prefs/sprite_accessories/tails/tails_lizard.dm
@@ -11,6 +11,7 @@
 /datum/sprite_accessory/tails/lizard/axolotl
 	name = "Axolotl"
 	icon_state = "axolotl"
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/gecko
 	name = "Gecko"
@@ -25,6 +26,7 @@
 /datum/sprite_accessory/tails/lizard/raptor
 	name = "Raptor"
 	icon_state = "raptor"
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/short
 	name = "Short"
@@ -36,10 +38,12 @@
 	name = "Short Two-Tone"
 	icon_state = "short2tone"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/slim
 	name = "Slim"
 	icon_state = "reptileslim"
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/smooth
 	name = "Smooth"
@@ -61,32 +65,38 @@
 	icon_state = "ltiger"
 	can_wag = TRUE
 
-/datum/sprite_accessory/tails/lizard/snake_under
+/datum/sprite_accessory/tails/lizard/rattlesnake
 	name = "Rattlesnake"
 	icon_state = "rattlesnake"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/snake
 	name = "Snake"
 	icon_state = "snaketail"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/snake_dual
 	name = "Snake Dual"
 	icon_state = "snakedual"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/snake_stripe
 	name = "Snake Stripe"
 	icon_state = "snakestripe"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/snake_stripe_alt
 	name = "Snake Stripe Alt"
 	icon_state = "snakestripealt"
 	can_wag = TRUE
+	spine_key = NONE
 
 /datum/sprite_accessory/tails/lizard/snake_under
 	name = "Snake Undertail"
 	icon_state = "snakeunder"
 	can_wag = TRUE
+	spine_key = NONE


### PR DESCRIPTION

## About The Pull Request

Mark more lizard tails with `sprite_key = NONE` because they look broken with tail spines, also fixed the rattlesnake tail having the wrong path and thus not existing

## Why It's Good For The Game

Fixes #243 (After this change I couldn't reproduce what was described here, and I couldn't find any bug related to it in the code, I'm wondering if there was confusion with tail spines vs spines because a tail with no tail spine support still lets a lizard have spines, they just don't extend down the tail. It's also possible the bug was fixed incidentally during another pref code fix)

## Changelog
:cl:
fix: fixed some lizard tails having tail spines when they shouldn't
fix: the rattlesnake tail is now selectable
/:cl:
