### PR TITLE
Revert "Stops overclocked volume pumps from working inside walls."

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -77,12 +77,14 @@
 	var/output_starting_pressure = air2.return_pressure()
 
 	// Requires being able to leak air in order to overclock.
+	/* EffigyEdit Remove - Boooo
 	if(overclocked)
 		var/turf/turf = loc
 		if(isclosedturf(turf))
 			balloon_alert_to_viewers("jammed!")
 			overclocked = FALSE
 			update_appearance(UPDATE_ICON)
+	*/// EffigyEdit Remove End
 
 	if((input_starting_pressure < VOLUME_PUMP_MINIMUM_OUTPUT_PRESSURE) || ((output_starting_pressure > VOLUME_PUMP_MAX_OUTPUT_PRESSURE)) && !overclocked)
 		return


### PR DESCRIPTION

## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/94007

## Why It's Good For The Game

Sucks

## Changelog
:cl:
balance: overclocked volume pumps work inside walls again
/:cl:
