### PR TITLE
Fix runtime with init_message_clients

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -617,7 +617,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 
 	GLOB.clients -= src
 	GLOB.directory -= ckey
-	LAZYREMOVE(GLOB.init_message_clients, src) // EffigyEdit Add - Custom Lobby
+	GLOB.init_message_clients -= src // EffigyEdit Add - Custom Lobby
 	if(persistent_client)
 		persistent_client.set_client(null)
 	else


### PR DESCRIPTION

## About The Pull Request

This is not a lazy list so `LAZYREMOVE` nulls it and the next addition to it turns it into not a list but a ref to an individual client, causing runtimes on further additions

## Why It's Good For The Game

Bug

## Changelog

N/A
