### PR TITLE
Fix RimPoint boulder refinery

### DIFF
--- a/_maps/effigy/map_files/RimPoint/RimPoint.dmm
+++ b/_maps/effigy/map_files/RimPoint/RimPoint.dmm
@@ -42383,7 +42383,9 @@
 /obj/machinery/conveyor{
 	id = "mining"
 	},
-/obj/machinery/brm,
+/obj/machinery/brm{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "orX" = (


### PR DESCRIPTION
## About The Pull Request
Fixes rotation of RimPoint boulder refinery

Closes https://github.com/effigy-se/effigy/issues/349

## Changelog

:cl: LT3
fix: Fixed RimPoint boulder refinery being backwards
/:cl: