### PR TITLE
Discord and wiki stat panel buttons

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -9,6 +9,8 @@
 		to_chat(src, span_danger("The wiki URL is not set in the server configuration."))
 		return
 
+	// EffigyEdit Change - Wiki Config
+	/*
 	var/query = tgui_input_text(src,
 		"Type what you want to know about. This will open the wiki in your web browser. Type nothing to go to the main page.",
 		"Wiki",
@@ -20,6 +22,9 @@
 	if(query != "")
 		output += "?title=Special%3ASearch&profile=default&search=[query]"
 	DIRECT_OUTPUT(src, link(output))
+	*/
+	DIRECT_OUTPUT(src, link(wikiurl))
+	// EffigyEdit Change End
 
 /client/verb/forum()
 	set name = "forum"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -166,7 +166,7 @@ window "infobuttons"
 		text = "Settings"
 		command = "Game-Preferences"
 		is-flat = true
-	elem "emotes"
+    elem "fullscreen-toggle"
 		type = BUTTON
 		pos = 277,4
 		size = 88x27
@@ -175,22 +175,22 @@ window "infobuttons"
 		font-family = "Chakra Petch"
 		background-color = none
 		saved-params = "is-checked"
-		text = "Emotes"
-		command = "Emote-Panel"
+		text = "Fullscreen"
+		command = "fullscreen"
 		is-flat = true
-	elem "fullscreen-toggle"
+	elem "wiki"
 		type = BUTTON
-		pos = 369,4
+        pos = 369,4
 		size = 88x27
 		anchor1 = 56,0
 		anchor2 = 70,100
 		font-family = "Chakra Petch"
 		background-color = none
 		saved-params = "is-checked"
-		text = "Fullscreen"
-		command = "fullscreen"
+		text = "Wiki"
+		command = "wiki"
 		is-flat = true
-	elem "webmap"
+	elem "discord"
 		type = BUTTON
 		pos = 461,4
 		size = 88x27
@@ -199,8 +199,8 @@ window "infobuttons"
 		font-family = "Chakra Petch"
 		background-color = none
 		saved-params = "is-checked"
-		text = "Webmap"
-		command = ".openWebMap"
+		text = "Discord"
+		command = "discord"
 		is-flat = true
 	elem "reconnect"
 		type = BUTTON

--- a/tgui/packages/tgui-panel/settings/themes.ts
+++ b/tgui/packages/tgui-panel/settings/themes.ts
@@ -61,10 +61,12 @@ export function setClientTheme(name): void | Promise<void> {
     // EffigyEdit Add Start
     'character.background-color': themeColor.BUTTON,
     'character.text-color': themeColor.TEXT,
+    'discord.background-color': '#5865f2',
+    'discord.text-color': themeColor.TEXT,
     'settings.background-color': themeColor.BUTTON,
     'settings.text-color': themeColor.TEXT,
-    'webmap.background-color': themeColor.BUTTON,
-    'webmap.text-color': themeColor.TEXT,
+    'wiki.background-color': '#5865f2',
+    'wiki.text-color': themeColor.TEXT,
     // EffigyEdit Add End
     // Status and verb tabs
     'output.background-color': themeColor.BG_BASE,


### PR DESCRIPTION
## About The Pull Request

Re-adds the Discord and Wiki buttons to the stat panel menu bar

## Changelog

:cl: LT3
qol: Discord and Wiki buttons have returned to the stat panel
/:cl: