### PR TITLE
Fix eternally sleeping proc on clients

### DIFF
--- a/code/game/sound/sound.dm
+++ b/code/game/sound/sound.dm
@@ -199,6 +199,10 @@
 
 /client/proc/playtitlemusic(volume_multiplier = 1)
 	set waitfor = FALSE
+	// EffigyEdit Add - Custom Lobby
+	if(CONFIG_GET(flag/use_scheduled_lobby_track))
+		return
+	// EffigyEdit Add End
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	var/music_volume = prefs.read_preference(/datum/preference/numeric/volume/sound_lobby_volume) * volume_multiplier


### PR DESCRIPTION

## About The Pull Request

This proc sets waitfor to false and then waits for the lobby music track to get set, but with our custom lobby code it never is and the proc sleeps forever

## Why It's Good For The Game

Bug

## Changelog

N/A
