### PR TITLE
Remove delete RSC part of build.bat

### DIFF
--- a/tools/build/build.bat
+++ b/tools/build/build.bat
@@ -1,3 +1,2 @@
 @echo off
-del "effigy.rsc"
 "%~dp0\..\bootstrap\javascript.bat" "%~dp0\build.ts" %*


### PR DESCRIPTION

## About The Pull Request

This is useful once in a blue moon when icons get moved around and trigger the bug with the RSC cache but the rest of the time it prevents Juke from skipping re-compilation between server launches if nothing has changed in the code

## Why It's Good For The Game

Don't like re-compiling every time

## Changelog

N/A
